### PR TITLE
Update Ethereum airdrops and switch to ftfy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 credentials*
 *.log
 */.idea
+
+.idea/
+
+venv/

--- a/cogs/automod.py
+++ b/cogs/automod.py
@@ -329,7 +329,7 @@ class AutoMod(commands.Cog):
         ) and act
 
         if spam_cond:
-            # Not a command or something
+            # Not a command or somethingmaster...tazz4843
             self.message_history[check_message.message.author].append(check_message.message)  # Add content for repeat-check later.
             self.message_history.reset_expiry(check_message.message.author)
 

--- a/cogs/automod.py
+++ b/cogs/automod.py
@@ -329,7 +329,7 @@ class AutoMod(commands.Cog):
         ) and act
 
         if spam_cond:
-            # Not a command or somethingmaster...tazz4843
+            # Not a command or something
             self.message_history[check_message.message.author].append(check_message.message)  # Add content for repeat-check later.
             self.message_history.reset_expiry(check_message.message.author)
 

--- a/cogs/helpers/triggers.py
+++ b/cogs/helpers/triggers.py
@@ -10,7 +10,6 @@ import typing
 from typing import List
 
 import discord
-import unicodedata
 import ftfy
 
 if typing.TYPE_CHECKING:

--- a/cogs/helpers/triggers.py
+++ b/cogs/helpers/triggers.py
@@ -11,6 +11,7 @@ from typing import List
 
 import discord
 import unicodedata
+import ftfy
 
 if typing.TYPE_CHECKING:
     from cogs.automod import CheckMessage
@@ -100,7 +101,8 @@ class LibraCryptoDiscordBots(AutoTrigger):
                                            "okey that im sharing this but i claimed 1200$",
                                            "i got 1400 dollars worth of 1inch tokens",
                                            "1inch",
-                                           "1inch-airdrop.net"], normalize=True)
+                                           "1inch-airdrop.net",
+                                           "etherаirdrop.net"], normalize=True)
 
         assert await member_joined_x_days_ago(self.message.author, x=2)
         return True
@@ -199,7 +201,7 @@ async def message_contains_x_of(message: discord.Message, x: int, texts: List[st
     assert x > 0
 
     if normalize:
-        content = unicodedata.normalize('NFKC', message.content).lower().strip()
+        content = ftfy.fix_text(message.content, normalization='NFKC').lower().strip()
     else:
         content = message.content.lower().strip()
 

--- a/cogs/helpers/triggers.py
+++ b/cogs/helpers/triggers.py
@@ -102,7 +102,8 @@ class LibraCryptoDiscordBots(AutoTrigger):
                                            "i got 1400 dollars worth of 1inch tokens",
                                            "1inch",
                                            "1inch-airdrop.net",
-                                           "etherаirdrop.net"], normalize=True)
+                                           "etherаirdrop.net",
+                                           "ethereum аirdrop"], normalize=True)
 
         assert await member_joined_x_days_ago(self.message.author, x=2)
         return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ objgraph
 psutil
 uvloop
 py-trello
+ftfy


### PR DESCRIPTION
This PR switches to using [`ftfy`](https://pypi.org/project/ftfy) over unicodedata, since `ftfy` seems to be more reliable in general. It also adds the new types of airdrop DuckHunt's been getting recently